### PR TITLE
only get keys with value

### DIFF
--- a/src/lib/redisFunctions.ts
+++ b/src/lib/redisFunctions.ts
@@ -24,8 +24,10 @@ export async function getAllOffersFromKeys(keys: string[]): Promise<any[]> {
   return await getAllHashes(offerIds);
 }
 
-export function stringsToKeys(value: string): string {
-  return value.toLowerCase().replace(/\s+/g, "");
+export function stringsToKeys(value: string): string | void {
+  if (value) {
+    return value.toLowerCase().replace(/\s+/g, "");
+  }
 }
 
 export async function searchRedis(searchTerm: string): Promise<any[]> {

--- a/src/models/redisDestinationAlert.ts
+++ b/src/models/redisDestinationAlert.ts
@@ -1,11 +1,7 @@
 import redis from "../lib/redis";
 import { logger } from "../lib/logger";
 import { IUser, IAlertObject, IAvailableOffers } from "../types";
-import {
-  getAllHashes,
-  getAllOffersFromKeys,
-  stringsToKeys
-} from "../lib/redisFunctions";
+import { getAllHashes, stringsToKeys } from "../lib/redisFunctions";
 
 function getKey(value: any, keyType: string): string {
   return `${keyType}:${value}`;
@@ -55,17 +51,23 @@ async function getAvailableOffers(
   destinationAlert: any
 ): Promise<IAvailableOffers> {
   return {
-    continent: await getAllOffersFromKeys([
-      `locations:continent:${stringsToKeys(destinationAlert.continent)}`
-    ]),
-    country: await getAllOffersFromKeys([
-      `locations:country:${stringsToKeys(destinationAlert.country)}`
-    ]),
-    administrative_area_level_1: await getAllOffersFromKeys([
+    continent: await redis.zrange(
+      `locations:continent:${stringsToKeys(destinationAlert.continent)}`,
+      0,
+      -1
+    ),
+    country: await redis.zrange(
+      `locations:country:${stringsToKeys(destinationAlert.country)}`,
+      0,
+      -1
+    ),
+    administrative_area_level_1: await redis.zrange(
       `locations:administrative_area_level_1:${stringsToKeys(
         destinationAlert.administrative_area_level_1
-      )}`
-    ])
+      )}`,
+      0,
+      -1
+    )
   };
 }
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -9,15 +9,21 @@ function authorizationToCookie(bearerToken: string): string {
 export async function getUser(requestHeaders: any): Promise<AuthResponse> {
   const url = `https://${process.env.API_BASE_URL}/current_user`;
   delete requestHeaders.host;
-  const headers = {
-    Origin: `https://${process.env.WEBSITE_BASE_URL}`,
-    Cookie:
-      requestHeaders.cookie ||
-      authorizationToCookie(
-        requestHeaders.authorization.replace("Bearer ", "")
-      ),
-    Authorization: requestHeaders.authorization
-  };
+  let headers;
+  try {
+    headers = {
+      Origin: `https://${process.env.WEBSITE_BASE_URL}`,
+      Cookie:
+        requestHeaders.cookie ||
+        authorizationToCookie(
+          requestHeaders.authorization.replace("Bearer ", "")
+        ),
+      Authorization: requestHeaders.authorization
+    };
+  } catch (err) {
+    logger("error", "AuthResponse", err);
+    return { status: 403, user: undefined };
+  }
   const options = {
     method: "GET",
     headers

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,9 @@ interface IGeocode {
 }
 
 export interface IAvailableOffers {
-  continent: object[];
-  country: object[];
-  administrative_area_level_1: object[];
+  continent: string[];
+  country: string[];
+  administrative_area_level_1: string[];
 }
 
 interface IAlert {


### PR DESCRIPTION
Fixes a couple of things:

- deals with empty key string,
- deals with empty headers,
- changes the response in `available_offers` to a list of strings