### PR TITLE
changing key for alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ All redis keys currently have a prefix that helps with identifying the object, k
   - locations:holidayType:{holidayType} == key used in sorted set for which offers have a certain holidayType. 
   - locations:country:{country_name} == key used in sorted set for which offers are saved against the country they are found in. 
   - destinationAlerts:{user.UUID} == key used to store a list of destination alert for that user. 
-  - alert:{alert.UUID} == key used to store a hash of a destination alert. 
+  - alert:{alert.place_id} == key used to store a hash of a destination alert. 
   - popularLocations key used to store a set of a popularDestiontions. 
   - popularLocation:{popularDestination.tag} key used to store a set of a location alerts, used to make up a popular destination. 
 

--- a/src/controllers/locationAlertController.ts
+++ b/src/controllers/locationAlertController.ts
@@ -2,7 +2,6 @@ import { Request, Response } from "express";
 import {
   getUserDestinationAlerts,
   createUserDestinationAlert,
-  updateUserDestinationAlert,
   deleteUserDestinationAlert
 } from "../models/destinationAlert";
 import schemas from "../schema/locationAlertSchema";
@@ -29,29 +28,6 @@ export async function createAlert(
   }
   try {
     await createUserDestinationAlert(req.body, req.user);
-  } catch (err) {
-    logger("error", "Error updating alert", err);
-    res.status(500);
-    return res.json("Error updating alert");
-  }
-  res.status(201);
-  return res.json(req.body);
-}
-
-export async function updateAlert(
-  req: Request,
-  res: Response
-): Promise<Response | void> {
-  const errors = schemas.locationAlertSchema.match(req.body);
-  if (errors.length) {
-    res.status(400);
-    logger("error", "Schema Error", errors);
-    res.json({ errors });
-    return res.end();
-  }
-  req.body.id = req.params.id;
-  try {
-    await updateUserDestinationAlert(req.body, req.user);
   } catch (err) {
     logger("error", "Error updating alert", err);
     res.status(500);

--- a/src/controllers/popularDestinationController.ts
+++ b/src/controllers/popularDestinationController.ts
@@ -2,7 +2,6 @@ import { Request, Response } from "express";
 import {
   getPopularDestinations,
   createPopularDestination,
-  updatePopularDestination,
   deletePopularDestination
 } from "../models/popularDestination";
 import schemas from "../schema/locationAlertSchema";
@@ -27,22 +26,6 @@ export async function create(
   }
   const popularDestination = await createPopularDestination(req.body);
   res.status(201);
-  return res.json(popularDestination);
-}
-
-export async function update(
-  req: Request,
-  res: Response
-): Promise<Response | void> {
-  const errors = schemas.locationAlertSchema.match(req.body);
-  if (errors.length) {
-    res.status(400);
-    res.json({ errors });
-    return res.end();
-  }
-  req.body.id = req.params.id;
-  const popularDestination = await updatePopularDestination(req.body);
-  res.status(202);
   return res.json(popularDestination);
 }
 

--- a/src/lib/redisFunctions.ts
+++ b/src/lib/redisFunctions.ts
@@ -1,5 +1,5 @@
 import redis from "../lib/redis";
-import { IPopularLocation, IAlertObject, IUser, IUserAlerts } from "../types";
+import { IPopularLocation, IAlertObject, IUserAlerts } from "../types";
 
 const KEY_LIMIT = process.env.KEY_LIMIT || 100;
 const POPULAR_LOCATION_TAG_TYPE =
@@ -159,18 +159,13 @@ export function buildAlertObject(flatAlert: any): IAlertObject {
   };
 }
 
-export function flattenAlertObject(
-  locationAlert: IAlertObject,
-  user?: IUser
-): object {
+export function flattenAlertObject(locationAlert: IAlertObject): object {
   return {
     id: locationAlert.id,
     tag_type: locationAlert.tag_type || "alert",
     tag_value: locationAlert.tag_value || "alert",
     place_id: locationAlert.place_id,
     brand: locationAlert.brand,
-    personContactId: user ? user.personContactId : "",
-    herokuId: user ? user.herokuId : "",
     level: locationAlert.location_alert.level,
     value: locationAlert.location_alert.value,
     lng: locationAlert.location_alert.geocode.lng,

--- a/src/models/destinationAlert.ts
+++ b/src/models/destinationAlert.ts
@@ -3,14 +3,12 @@ import { logger } from "../lib/logger";
 import {
   getUserDestinationAlertsSFMC,
   createUserDestinationAlertSFMC,
-  updateUserDestinationAlertSFMC,
   deleteUserDestinationAlertSFMC
 } from "../services/marketingCloud";
 
 import {
   getUserDestinationAlertsRedis,
   createUserDestinationAlertRedis,
-  updateUserDestinationAlertRedis,
   deleteUserDestinationAlertRedis
 } from "./redisDestinationAlert";
 import { getContinent } from "../lib/countryToContinent";
@@ -42,23 +40,6 @@ export async function createUserDestinationAlert(
     });
   }
   return await createUserDestinationAlertRedis(locationAlert, user);
-}
-
-export async function updateUserDestinationAlert(
-  locationAlert: IAlertObject,
-  user: IUser
-): Promise<IAlertObject> {
-  locationAlert.google_result.continent = getContinent(locationAlert);
-  try {
-    updateUserDestinationAlertSFMC(locationAlert, user);
-  } catch (err) {
-    logger("error", "Error updating SFMC destination alert", {
-      locationAlert,
-      message: err.message,
-      user
-    });
-  }
-  return await updateUserDestinationAlertRedis(locationAlert, user);
 }
 
 export async function deleteUserDestinationAlert(

--- a/src/models/popularDestination.ts
+++ b/src/models/popularDestination.ts
@@ -2,7 +2,6 @@ import { IAlertObject } from "../types";
 import {
   getUserDestinationAlertsRedis,
   createUserDestinationAlertRedis,
-  updateUserDestinationAlertRedis,
   deleteUserDestinationAlertRedis
 } from "../models/redisDestinationAlert";
 
@@ -25,15 +24,6 @@ export async function createPopularDestination(
   locationAlert: IAlertObject
 ): Promise<IAlertObject> {
   return createUserDestinationAlertRedis(
-    locationAlert,
-    POPULAR_DESTINATION_USER
-  );
-}
-
-export async function updatePopularDestination(
-  locationAlert: IAlertObject
-): Promise<IAlertObject> {
-  return updateUserDestinationAlertRedis(
     locationAlert,
     POPULAR_DESTINATION_USER
   );

--- a/src/models/redisDestinationAlert.ts
+++ b/src/models/redisDestinationAlert.ts
@@ -24,7 +24,7 @@ export async function createUserDestinationAlertRedis(
 ): Promise<IAlertObject> {
   const key = getKey(user.herokuId, "destinationAlerts");
   try {
-    await redis.sadd(key, getKey(locationAlert.id, "alert"));
+    await redis.sadd(key, getKey(locationAlert.place_id, "alert"));
   } catch (err) {
     logger(
       "error",
@@ -34,31 +34,17 @@ export async function createUserDestinationAlertRedis(
     throw err;
   }
   try {
-    await redis.hmset(
-      getKey(locationAlert.id, "alert"),
-      flattenAlertObject(locationAlert, user)
-    );
+    if (!(await redis.exists(locationAlert.place_id))) {
+      await redis.hmset(
+        getKey(locationAlert.place_id, "alert"),
+        flattenAlertObject(locationAlert, user)
+      );
+    }
   } catch (err) {
     logger("error", "Error setting user destination alerts list in redis", err);
     throw err;
   }
   return locationAlert;
-}
-
-export async function updateUserDestinationAlertRedis(
-  locationAlert: IAlertObject,
-  user: IUser
-): Promise<IAlertObject> {
-  try {
-    await redis.hmset(
-      getKey(locationAlert.id, "alert"),
-      flattenAlertObject(locationAlert, user)
-    );
-    return locationAlert;
-  } catch (err) {
-    logger("error", "Error updating destination alert in redis", err);
-    throw err;
-  }
 }
 
 export async function deleteUserDestinationAlertRedis(

--- a/src/models/redisDestinationAlert.ts
+++ b/src/models/redisDestinationAlert.ts
@@ -37,7 +37,7 @@ export async function createUserDestinationAlertRedis(
     if (!(await redis.exists(locationAlert.place_id))) {
       await redis.hmset(
         getKey(locationAlert.place_id, "alert"),
-        flattenAlertObject(locationAlert, user)
+        flattenAlertObject(locationAlert)
       );
     }
   } catch (err) {
@@ -48,14 +48,12 @@ export async function createUserDestinationAlertRedis(
 }
 
 export async function deleteUserDestinationAlertRedis(
-  id: string,
+  place_id: string,
   user: IUser
 ): Promise<void> {
   try {
-    const alertKey = getKey(id, "alert");
-    await redis.del(alertKey);
     const destinationKey = getKey(user.herokuId, "destinationAlerts");
-    return await redis.srem(destinationKey, id);
+    return await redis.srem(destinationKey, getKey(place_id, 'alert'));
   } catch (err) {
     logger("error", "Error deleting destination alert in redis", err);
     throw err;

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,12 +36,6 @@ export default function server(): any {
     popularDestinationController.create
   );
 
-  app.patch(
-    "/api/search/popular-destination/:id",
-    adminMiddleware,
-    popularDestinationController.update
-  );
-
   app.delete(
     "/api/search/popular-destination/:id",
     adminMiddleware,
@@ -102,12 +96,6 @@ export default function server(): any {
     "/api/search/location-alert",
     authMiddleware,
     locationAlertController.createAlert
-  );
-
-  app.patch(
-    "/api/search/location-alert/:id",
-    authMiddleware,
-    locationAlertController.updateAlert
   );
 
   app.delete(

--- a/src/services/marketingCloud.ts
+++ b/src/services/marketingCloud.ts
@@ -214,13 +214,6 @@ export async function createUserDestinationAlertSFMC(
   await createUpdateRequest(locationAlert, user);
 }
 
-export async function updateUserDestinationAlertSFMC(
-  locationAlert: IAlertObject,
-  user: IUser
-): Promise<void> {
-  await createUpdateRequest(locationAlert, user);
-}
-
 export async function deleteUserDestinationAlertSFMC(
   id: string,
   user: IUser

--- a/tests/locationsAlertController.test.ts
+++ b/tests/locationsAlertController.test.ts
@@ -37,12 +37,12 @@ const payload = {
 describe('test locationAlertController Auth', () => {
   let authStub;
 
-  beforeEach(async () => {
+  before(async () => {
     authStub = sinon.stub(auth, 'getUser');
     authStub.returns(Promise.resolve({status: 401, undefined}))
   });
 
-  afterEach(function() {
+  after(function() {
     authStub.restore();
   });
 
@@ -54,14 +54,6 @@ describe('test locationAlertController Auth', () => {
   it("create location requires auth", async () => {
     const resp = await chai.request(app)
       .post("/api/search/location-alert")
-      .set("content-type", "application/json")
-      .send(payload);
-    expect(resp.status).to.equal(401);
-  });
-
-  it("update location requires auth", async () => {
-    const resp = await chai.request(app)
-      .patch("/api/search/location-alert/1")
       .set("content-type", "application/json")
       .send(payload);
     expect(resp.status).to.equal(401);
@@ -113,15 +105,8 @@ describe('test locationAlertController', () => {
     expect(resp.status).to.equal(400);
   });
 
-  it("update location requires correct schema", async () => {
-    const resp = await chai.request(app)
-      .patch("/api/search/location-alert/1")
-      .set("content-type", "application/json")
-      .send({});
-    expect(resp.status).to.equal(400);
-  });
 
-  it("create location creates locationAlert", async () => {
+  it("creates locationAlert", async () => {
     soapStub = sinon.stub(m, 'createUserDestinationAlertSFMC')
     soapStub.returns(Promise.resolve())
     const resp = await chai.request(app)


### PR DESCRIPTION
More than one thing is happerning within this PR:

The key for alerts is changing from `alert:uuid` to `alert:place_id` meaning that we can do lookups on place id and removing the connection from each alert being assigned to a different user.

Secondly we realized that there was no need to update alerts so that functionality has been removed